### PR TITLE
Add Vocabulary Dropout for Curriculum Diversity in LLM Co-Evolution (COLM'26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Agentic Self-Evolving represents a paradigm shift in AI development, enabling sy
 - (ICLR'26) Steporlm: A self-evolving framework with generative process supervision for operations research language models [[Paper]](https://arxiv.org/abs/2509.22558)
 - (NeurIPS'24) Coevolving with the other you: Fine-tuning llm with sequential cooperative multi-agent reinforcement learning [[Paper]](https://neurips.cc/virtual/2024/poster/95347)
 - (ICLR'26) R-zero: Self-evolving reasoning llm from zero data [[Paper]](https://arxiv.org/abs/2508.05004)
+- (COLM'26) Vocabulary Dropout for Curriculum Diversity in LLM Co-Evolution [[Paper]](https://arxiv.org/abs/2604.03472) [[Code]](https://github.com/ARC-ASU/vocab_dropout)
 - (arxiv'26) MM-Zero: Self-Evolving Multi-Model Vision Language Models From Zero Data
  [[Paper]](https://arxiv.org/abs/2603.09206)
 - (NeurIPS'25) Absolute zero: Reinforced self-play reasoning with zero data [[Paper]](https://neurips.cc/virtual/2025/loc/san-diego/poster/116121)


### PR DESCRIPTION
Adds our COLM 2026 paper to the Exploration-Driven Online Self-Evolving section, next to R-Zero, which it builds on.

The paper studies proposer-solver co-evolution in R-Zero, where the proposer's diversity collapse stalls the curriculum, and introduces vocabulary dropout, a hard non-stationary mask on the proposer's output vocabulary that sustains lexical, semantic, and functional diversity and improves the downstream solver.

- Paper: https://arxiv.org/abs/2604.03472
- Code: https://github.com/ARC-ASU/vocab_dropout

Thanks for the great survey, and thanks Zhishang for the invitation to submit this.