### PR TITLE
Add OpenSkill (Open-World Self-Evolution for LLM Agents) to Skill Augmented Evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Agentic Self-Evolving represents a paradigm shift in AI development, enabling sy
 - (arxiv'26) SkillsBench: Benchmarking How Well Agent Skills Work Across Diverse Tasks [[Paper]](https://arxiv.org/abs/2602.12670)
 - (arxiv'26) ARISE: Agent Reasoning with Intrinsic Skill Evolution in Hierarchical Reinforcement Learning [[Paper]](https://arxiv.org/abs/2603.16060)
 - (arxiv'26) Evolving Medical Imaging Agents via  Experience-driven Self-skill Discovery [[Paper]](https://arxiv.org/abs/2603.05860)
+- (arxiv'26) OpenSkill: Open-World Self-Evolution for LLM Agents [[Paper]](https://arxiv.org/abs/2606.06741) [[Code]](https://github.com/OpenLAIR/OpenSkill)
 
 
 


### PR DESCRIPTION
Adds **OpenSkill** to the Skill Augmented Evolution section.

OpenSkill (arXiv:2606.06741, OpenLAIR) is an open-world self-evolution framework for LLM agents that acquire and refine skills online in open environments — a direct fit alongside the skill-discovery/self-evolution entries here.

- Paper: https://arxiv.org/abs/2606.06741
- Code: https://github.com/OpenLAIR/OpenSkill

Matched the section's bullet + [[Paper]]/[[Code]] format. Thanks for maintaining this survey!